### PR TITLE
Fix prerelease variable not populating in link template generation

### DIFF
--- a/app/model/container.js
+++ b/app/model/container.js
@@ -100,7 +100,7 @@ function getLink(container, originalTagValue) {
         patch = versionSemver.patch;
         prerelease =
             versionSemver.prerelease && versionSemver.prerelease.length > 0
-                ? prerelease[0]
+                ? versionSemver.prerelease[0]
                 : '';
     }
     return eval('`' + container.linkTemplate + '`');


### PR DESCRIPTION
Previously, the assignment for the prerelease variable was referencing its own (uninitialized) value, i.e., prerelease = prerelease[0], rather than the parsed semver array. As a result, prerelease was always set to an empty string instead of the intended prerelease identifier.

This commit updates the code to assign prerelease from versionSemver.prerelease[0], ensuring the variable pulls the correct value from the parsed semver object.

Fixes #584